### PR TITLE
Fix trailing slash

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,6 +8,7 @@ import sitemap from "@astrojs/sitemap";
 export default defineConfig({
   site: "https://www.carlos-gamino.dev",
   integrations: [sitemap(), icon()],
+  trailingSlash: "always",
   i18n: {
     locales: ["es", "en"],
     defaultLocale: "en",


### PR DESCRIPTION
Corregir el problema mostrado en el siguiente correo:
Nuevo motivo que impide la indexación de páginas
Search Console identificó que algunas/os páginas de tu sitio no se indexaron por el siguiente motivo nuevo:

Duplicada: el usuario no ha indicado ninguna versión canónica

Si este motivo no es intencional, te recomendamos que lo corrijas para que se indexen las/los páginas afectadas/os y aparezcan en Google.
[Soporte de Google con el problema](https://support.google.com/webmasters/answer/7440203#duplicate_page_without_canonical_tag)